### PR TITLE
update max lora size to 400mb

### DIFF
--- a/addons/stable_horde_client/civitai_lora_model_fetch.gd
+++ b/addons/stable_horde_client/civitai_lora_model_fetch.gd
@@ -110,8 +110,8 @@ func _parse_civitai_lora_data(civitai_entry) -> Dictionary:
 			new_version["unusable"] = 'Attention! This LoRa is unusable because it does not provide file validation.'
 		elif not new_version.get("url"):
 			new_version["unusable"] = 'Attention! This LoRa is unusable because it appears to have no valid safetensors upload.'
-		elif new_version["size_mb"] > 230 and not default_ids.has(lora_details["id"]):
-			new_version["unusable"] = 'Attention! This LoRa is unusable because is exceeds the max 230Mb filesize we allow on the AI Horde.'
+		elif new_version["size_mb"] > 400 and not default_ids.has(lora_details["id"]):
+			new_version["unusable"] = 'Attention! This LoRa is unusable because is exceeds the max 400Mb filesize we allow on the AI Horde.'
 		new_version["images"] = []
 		for img in version["images"]:
 			if img["nsfwLevel"] > 2:


### PR DESCRIPTION
Lucid will need an update. This seemed a simple enough fix to just PR instead of notifying.


> I decided to give the lucid creations Godot client a try, but when tryin to load the same Lora, it gives me a warning that the hors cannot use loras bigger than 220mb or so, and the Lora it's incompatible...
> Does this means that all my generations from artbot, despise not having a warning or error, where processed whitout the Lora? Just the base checkpoint?
> I'm questioning whether the Lora has been used at all in my horde generations.... Or any Lora that I though was used but actually wasn't due to exeding limitations.

-- [magicxxxball](https://discord.com/channels/781145214752129095/1020695869927981086/1364372385158926388)
